### PR TITLE
Split request 'analysis/perform' to 'analysis/send' and 'analysis/{id}/start'

### DIFF
--- a/app/CommandService/CommandService.csproj
+++ b/app/CommandService/CommandService.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Commands\Commands.csproj"/>
-        <ProjectReference Include="..\Common\Common.csproj"/>
+        <ProjectReference Include="..\Commands\Commands.csproj" />
+        <ProjectReference Include="..\Common\Common.csproj" />
     </ItemGroup>
 
 </Project>

--- a/app/CommandService/Controllers/AnalysisController.cs
+++ b/app/CommandService/Controllers/AnalysisController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using CommandService.Dto;
 using CommandService.Services;
@@ -23,14 +24,29 @@ namespace CommandService.Controllers
         /// </summary>
         /// <param name="file">File to be analysed</param>
         /// <param name="authorization">JWT token, if not set request should be stopped at API Gateway</param>
-        /// <response code="202">File send to be analysed. </response>
+        /// <response code="200">File send to be analysed (analysis not started yet) </response>
         /// <returns></returns>
-        [HttpPost("perform")]
-        public async Task<IActionResult> PerformAnalysis(IFormFile file, [FromHeader] string authorization)
+        [HttpPost("send")]
+        public async Task<IActionResult> SendFileToAnalysis(IFormFile file, [FromHeader] string authorization)
         {
             var model = JwtUtil.GetUserIdFromToken(authorization);
-            var taskId = await _analysisService.PerformAnalysis(file, model.UserId);
-            return new AcceptedResult($"api/analysis/{taskId}", new PerformAnalysisResponse(taskId));
+            var fileId = await _analysisService.SendFileToAnalysis(file, model.UserId);
+            return new OkObjectResult(new SendFileToAnalysisResponse(fileId));
+        }
+
+        /// <summary>
+        ///     Sends command to start analysis of specified file
+        /// </summary>
+        /// <param name="id">Identifier of file to be analysed</param>
+        /// <param name="authorization">JWT token, if not set request should be stopped at API Gateway</param>
+        /// <response code="202">Analysis started</response>
+        /// <returns></returns>
+        [HttpPost("{id}/start")]
+        public async Task<IActionResult> AnalyzeFile([FromRoute] Guid id, [FromHeader] string authorization)
+        {
+            var model = JwtUtil.GetUserIdFromToken(authorization);
+            var taskId = await _analysisService.AnalyzeFile(id, model.UserId);
+            return new AcceptedResult($"api/analysis/{taskId}", new AnalysisResponse(taskId));
         }
     }
 }

--- a/app/CommandService/Dto/AnalysisResponse.cs
+++ b/app/CommandService/Dto/AnalysisResponse.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace CommandService.Dto
 {
-    public record PerformAnalysisResponse(Guid TaskId)
+    public record AnalysisResponse(Guid TaskId)
     {
     }
 }

--- a/app/CommandService/Dto/SendFileToAnalysisResponse.cs
+++ b/app/CommandService/Dto/SendFileToAnalysisResponse.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CommandService.Dto
+{
+    public record SendFileToAnalysisResponse (Guid FileId)
+    {
+        
+    }
+}

--- a/app/CommandService/Services/AnalysisService.cs
+++ b/app/CommandService/Services/AnalysisService.cs
@@ -16,11 +16,19 @@ namespace CommandService.Services
             _client = client;
         }
 
-        public async Task<Guid> PerformAnalysis(IFormFile file, Guid userId)
+        public async Task<Guid> SendFileToAnalysis(IFormFile file, Guid userId)
+        {
+            var fileId = Guid.NewGuid();
+            var fileModel = file.ToFileModel();
+            var command = new VerifyDocumentCommand(fileId, userId, fileModel, DateTime.Now);
+            await _client.PublishAsync(command);
+            return fileId;
+        }
+
+        public async Task<Guid> AnalyzeFile(Guid fileId, Guid userId)
         {
             var taskId = Guid.NewGuid();
-            var fileModel = file.ToFileModel();
-            var command = new VerifyDocumentCommand(taskId, userId, fileModel, DateTime.Now);
+            var command = new AnalyzeDocumentCommand(taskId, fileId, userId, DateTime.Now);
             await _client.PublishAsync(command);
             return taskId;
         }

--- a/app/CommandService/Services/IAnalysisService.cs
+++ b/app/CommandService/Services/IAnalysisService.cs
@@ -6,6 +6,8 @@ namespace CommandService.Services
 {
     public interface IAnalysisService
     {
-        Task<Guid> PerformAnalysis(IFormFile file, Guid userId);
+        Task<Guid> SendFileToAnalysis(IFormFile file, Guid userId);
+
+        Task<Guid> AnalyzeFile(Guid fileId, Guid userId);
     }
 }

--- a/app/Commands/AnalyzeDocumentCommand.cs
+++ b/app/Commands/AnalyzeDocumentCommand.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Commands
+{
+    public record AnalyzeDocumentCommand(Guid TaskId, Guid FileId, Guid UserId, DateTime IssuedTime)
+    {
+        
+    }
+}


### PR DESCRIPTION
[CHANGELOG]
- changed endpoint for sending files to analysis: 'perform' -> 'send'. Now it only uploads file, should not perform any analysis. Returns id of sent file
- added endpoint for starting analysis of given file: '{id}/start'